### PR TITLE
Add high-scores page and route; connect front to back

### DIFF
--- a/project_quazar/assets/css/app.css
+++ b/project_quazar/assets/css/app.css
@@ -2,4 +2,81 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
-/* This file is for your main application CSS */
+/* ******************** */
+/* All-Time High Scores */
+/* ******************** */
+.high-scores-container {
+    max-width: 400px;
+    margin: 20px auto;
+    padding: 15px;
+    background-color: #f9f9f9;
+    border: 5px solid #ddd;
+    border-radius: 8px;
+  }
+
+  .high-scores-container h1 {
+    text-align: center;
+    font-weight: bolder;
+
+  }
+
+  .high-scores-container ul {
+    list-style: none;
+    padding: 0;
+  }
+
+  .high-scores-container li {
+    margin: 10px 0;
+    padding: 10px;
+    background-color: #eee;
+    border-radius: 4px;
+  }
+
+  .high-scores-container .player {
+    font-weight: bold;
+  }
+
+  .high-scores-container .score {
+    float: right;
+  }
+
+
+  /* Base container styling */
+.base-container {
+  @apply bg-gray-900 p-6 rounded-lg shadow-lg max-w-md mx-auto;
+}
+
+/* Title styling */
+.title {
+  @apply text-white text-3xl font-bold text-center mb-6;
+}
+
+/* User list container */
+.user-list-container {
+  @apply flex flex-col space-y-4;
+}
+
+/* User item base styling */
+.user-item-base {
+  @apply flex justify-between items-center p-4 rounded-lg text-white font-semibold transition duration-300 ease-in-out transform hover:scale-105;
+}
+
+/* Current user item styling */
+.current-user-item {
+  @apply bg-green-600;
+}
+
+/* Other user item styling */
+.other-user-item {
+  @apply bg-gray-800;
+}
+
+/* Span styles for user id */
+.user-id {
+  @apply text-lg;
+}
+
+/* Span styles for user points */
+.user-points {
+  @apply text-xl text-yellow-400;
+}

--- a/project_quazar/lib/project_quazar_web/live/all_time_high_scores.ex
+++ b/project_quazar/lib/project_quazar_web/live/all_time_high_scores.ex
@@ -1,0 +1,49 @@
+defmodule ProjectQuazarWeb.AllTimeHighScoresLive do
+  use Phoenix.LiveView
+  alias Phoenix.PubSub
+  alias ProjectQuazar.HighScores
+
+  @impl true
+  def mount(_session, _params, socket) do
+    PubSub.subscribe(ProjectQuazar.PubSub, "high_scores:updates")
+    IO.puts("Subscribed to high_scores:updates")
+
+    case HighScores.fetch_top_scores() do
+      {:ok, top_scores} -> {:ok, assign(socket, :top_scores, top_scores)}
+      {:error, _reason} -> {:ok, assign(socket, :top_scores, [])}
+    end
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <div class="high-scores-container">
+      <h1>All-Time High Scores</h1>
+      <div id="scores">
+        <ul>
+          <%= for score <- @top_scores do %>
+            <li>
+              <span class="player"><%= score.player %></span>
+              <span class="score"><%= score.score %></span>
+            </li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+    """
+  end
+
+  @impl true
+  def handle_info(:scores_updated, socket) do
+    IO.puts("Received scores_updated in LiveView")
+
+    case HighScores.fetch_top_scores() do
+      {:ok, top_scores} ->
+        updated_socket = assign(socket, :top_scores, top_scores)
+        IO.inspect(updated_socket, label: "Updated top_scores")
+        {:noreply, updated_socket}
+
+      {:error, _reason} -> {:noreply, assign(socket, :top_scores, [])}
+    end
+  end
+end

--- a/project_quazar/lib/project_quazar_web/router.ex
+++ b/project_quazar/lib/project_quazar_web/router.ex
@@ -18,6 +18,7 @@ defmodule ProjectQuazarWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    live "/high-scores", AllTimeHighScoresLive, :show
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
### Summary

Created a high-scores page with basic styling; connected this to Shawn's backend, which I updated slightly.

The styling will be updated.

### Testing
1. Check out this branch
2. Open a terminal at the `project_quazar` folder inside the project (NOT the titlecase `Project_Quazar`
3. Run `iex -S mix phx.server`; it should build and start the server
4. Open Google Chrome at `localhost:4000\high-scores`
5. You should see a white screen with the text "All-Time High Scores" in a grey-bordered box.
6. Put the Chrome window and the terminal side-by-side
7. Type or copy-and-paste in the following command and press ENTER: `ProjectQuazar.HighScores.ETSWrapper.insert_entry("Player1", 12500)`

10. You should immediately see the score in the Chrome window