### PR TITLE
Removing player if they have been dead for longer then 2 seconds

### DIFF
--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -5,12 +5,10 @@ defmodule GameServer do
   defstruct [:players, :projectiles]
 
   @table GameState
-
-  @accel_rate 0.25
-  @score_increment 100
+  # Ticks/second
+  @tick_rate 20
   # Time in seconds before a dead player is removed from the game state (2 seconds)
   @dead_removal_interval_sec 2000
-  @tick_rate 20
   @drag_rate 0.2
   @turn_rate :math.pi() / 3 * 0.1
   @health_increment 1

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -5,10 +5,11 @@ defmodule GameServer do
   defstruct [:players, :projectiles]
 
   @table GameState
-  
+
   @accel_rate 0.25
   @score_increment 100
-  @dead_time 2000
+  # Time in seconds before a dead player is removed from the game state (2 seconds)
+  @dead_removal_interval_sec 2000
   @tick_rate 20
   @drag_rate 0.2
   @turn_rate :math.pi() / 3 * 0.1
@@ -225,7 +226,7 @@ defmodule GameServer do
           # increments the health of the player
           |> Player.inc_health(@health_increment)
         else
-          Process.send_after(self(), {:check_player_health, player.name}, @dead_time)
+          Process.send_after(self(), {:check_player_health, player.name}, @dead_removal_interval_sec)
           player
         end
       end)


### PR DESCRIPTION
Implemented a feature that removes the player from the game state if they have been dead for longer then 2 seconds
Defined a variable at the top of game_server.ex called @dead_time, if you want to change it from 2 seconds to something else
If you want to test:
1. manually set the ships health (change the ships in ship module to start with hp < 0)
2. run the program and join the game
3. you should see after two seconds you get removed from the gamestate, or your "player" will stop being printed