### PR TITLE
Add player input handling

### DIFF
--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -102,7 +102,7 @@ defmodule GameServer do
     Enum.map(players, fn p -> if p.name == updated_player.name, do: updated_player, else: p end)
   end
 
-  @doc "Used for testing how players can interact/move."
+  @doc "Used to update the players inputs, movement, and other features every tick."
   def modify_players(players) do
     if length(players) == 0 do
       [] # Return the empty list if no players.

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -19,9 +19,11 @@ defmodule GameServer do
     damage_zone: 100
   }
 
+  @doc "Spawns a new player within the screen boundaries of a specific type and bullet style."
   def spawn_player(name, ship_type, bullet_type),
     do: GenServer.cast({:global, __MODULE__}, {:spawn_player, name, ship_type, bullet_type})
 
+  @doc "Adds a bullet that was fired from the player."
   def add_projectile(bullet), do: GenServer.cast({:global, __MODULE__}, {:add_projectile, bullet})
 
   @doc "Pings server for debugging."

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -245,7 +245,7 @@ defmodule GameServer do
     # Update the passed players input mappings
     new_players = Enum.map(players, fn player ->
       if player.name == username do
-        Player.update_player_inputs(player, input_type, pressed_or_released)
+        Player.update_inputs(player, input_type, pressed_or_released)
       else
         player
       end

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -63,9 +63,19 @@ defmodule GameServer do
     GenServer.cast({:global, __MODULE__}, {:input, :accelerate, :pressed, name})
   end
 
-  @doc "Stops accelerating the specfied player."
+  @doc "Stops accelerating the specified player."
   def accelerate_released(name) do
     GenServer.cast({:global, __MODULE__}, {:input, :accelerate, :released, name})
+  end
+
+  @doc "Starts braking the specified Player."
+  def brake_pressed(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :brake, :pressed, name})
+  end
+
+  @doc "Stops accelerating the specfied player."
+  def brake_released(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :brake, :released, name})
   end
 
   @doc "Turns a specfied player right (clockwise)."

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -56,42 +56,42 @@ defmodule GameServer do
 
   @doc "Accelerates the Player with the given name."
   def accelerate_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :accelerate_pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :accelerate, :pressed, name})
   end
 
   @doc "Stops accelerating the specfied player."
   def accelerate_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :accelerate_released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :accelerate, :released, name})
   end
 
   @doc "Turns a specfied player right (clockwise)."
   def turn_right_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_right_pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_right, :pressed, name})
   end
 
   @doc "Stops a specfied player from turning right."
   def turn_right_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_right_released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_right, :released, name})
   end
 
   @doc "Turns a specfied player left (counter-clockwise)."
   def turn_left_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_left_pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_left, :pressed, name})
   end
 
   @doc "Stops a specfied player from turning left."
   def turn_left_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_left_released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_left, :released, name})
   end
 
   @doc "Fires bullets from a specfied player."
   def fire_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :fire_pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :fire, :pressed, name})
   end
 
   @doc "Stops firing bullets from a specified player."
   def fire_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :fire_released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :fire, :released, name})
   end
 
   @doc "Handles all idle ship movement/velocity. Should be called every tick."
@@ -280,5 +280,26 @@ defmodule GameServer do
     end)
 
     {:noreply, state}
+  end
+
+  @doc """
+  This handles any user input events and updates the associated player with the inputs.
+  """
+  @impl true
+  def handle_cast({:input, input_type, pressed_or_released, username}, %{players: players} = state) do
+    if pressed_or_released != :pressed && pressed_or_released != :released do
+      raise "Invalid button state passed, expected pressed or released got #{pressed_or_released}"
+    end
+    # Update the passed players input mappings
+    new_players = Enum.map(players, fn player ->
+      if player.name == username do
+        Player.update_player_inputs(player, input_type, pressed_or_released)
+      else
+        player
+      end
+    end)
+    # Return updated input state
+    new_state = %{state | players: new_players}
+    {:noreply, new_state}
   end
 end

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -183,9 +183,7 @@ defmodule GameServer do
     {:reply, gamestate}
   end
 
-  """
-  Spawns a new player within the screen boundaries of a specific type and bullet style.
-  """
+  # Spawns a new player within the screen boundaries of a specific type and bullet style.
   @impl true
   def handle_cast({:spawn_player, name, type, bullet_type}, %__MODULE__{players: players} = gamestate) do
     player_ship = Ship.random_ship(type, bullet_type, @bounds)
@@ -201,9 +199,7 @@ defmodule GameServer do
   end
 
 
-  """
-  Adds a bullet that was fired from the player.
-  """
+  # Adds a bullet that was fired from the player.
   @impl true
   def handle_cast({:add_projectile, bullet}, %{projectiles: projectiles} = state) do
     # Add the new bullet to the projectile list
@@ -211,9 +207,7 @@ defmodule GameServer do
     {:noreply, %{state | projectiles: new_projectiles}}
   end
 
-  """
-  Removes a player from the game state.
-  """
+  # Removes a player from the game state.
   @impl true
   def handle_cast({:remove_player, name}, %{players: players} = state) do
     new_players = Enum.reject(players, fn player -> player.name == name end)
@@ -221,13 +215,11 @@ defmodule GameServer do
     {:noreply, new_state}
   end
 
-  """
-  Removes players that are not in the presence list. This is to ensure
-  that leftover players are removed from the game state.
-  """
+  # Removes players that are not in the presence list. This is to ensure
+  # that leftover players are removed from the game state.
   @impl true
   def handle_cast({:remove_leftover_players, presence_list}, %{players: players} = state) do
-    state.players
+    players
     |> Enum.map(& &1.name)
     |> Enum.each(fn player ->
       if !Map.has_key?(presence_list, player) do
@@ -238,9 +230,7 @@ defmodule GameServer do
     {:noreply, state}
   end
 
-  """
-  This handles any user input events and updates the associated player with the inputs.
-  """
+  # This handles any user input events and updates the associated player with the inputs.
   @impl true
   def handle_cast({:input, input_type, pressed_or_released, username}, %{players: players} = state) do
     if pressed_or_released != :pressed && pressed_or_released != :released do

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -46,52 +46,52 @@ defmodule GameServer do
 
   @doc "Accelerates the Player with the given name."
   def accelerate_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :accelerate, :pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :accelerate, true, name})
   end
 
   @doc "Stops accelerating the specified player."
   def accelerate_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :accelerate, :released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :accelerate, false, name})
   end
 
   @doc "Starts braking the specified Player."
   def brake_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :brake, :pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :brake, true, name})
   end
 
   @doc "Stops accelerating the specfied player."
   def brake_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :brake, :released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :brake, false, name})
   end
 
   @doc "Turns a specfied player right (clockwise)."
   def turn_right_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_right, :pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_right, true, name})
   end
 
   @doc "Stops a specfied player from turning right."
   def turn_right_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_right, :released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_right, false, name})
   end
 
   @doc "Turns a specfied player left (counter-clockwise)."
   def turn_left_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_left, :pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_left, true, name})
   end
 
   @doc "Stops a specfied player from turning left."
   def turn_left_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :turn_left, :released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_left, false, name})
   end
 
   @doc "Fires bullets from a specfied player."
   def fire_pressed(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :fire, :pressed, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :fire, true, name})
   end
 
   @doc "Stops firing bullets from a specified player."
   def fire_released(name) do
-    GenServer.cast({:global, __MODULE__}, {:input, :fire, :released, name})
+    GenServer.cast({:global, __MODULE__}, {:input, :fire, false, name})
   end
 
   @doc "Handles any and all idle movement/velocity. Should be called every tick for any movable entity."
@@ -239,9 +239,6 @@ defmodule GameServer do
   # This handles any user input events and updates the associated player with the inputs.
   @impl true
   def handle_cast({:input, input_type, pressed_or_released, username}, %{players: players} = state) do
-    if pressed_or_released != :pressed && pressed_or_released != :released do
-      raise "Invalid button state passed, expected pressed or released got #{pressed_or_released}"
-    end
     # Update the passed players input mappings
     new_players = Enum.map(players, fn player ->
       if player.name == username do

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -6,7 +6,7 @@ defmodule GameServer do
 
   @table GameState
   # Ticks/second
-  @tick_rate 1
+  @tick_rate 20
   @drag_rate 0.2
   @turn_rate :math.pi() / 3 * 0.1
   @health_increment 1

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -50,6 +50,10 @@ defmodule GameServer do
     GenServer.cast({:global, __MODULE__}, {:remove_player, name})
   end
 
+  @doc """
+  Removes players that are not in the presence list. This is to ensure
+  that leftover players are removed from the game state.
+  """
   def remove_leftover_players(presence_list) do
     GenServer.cast({:global, __MODULE__}, {:remove_leftover_players, presence_list})
   end
@@ -239,23 +243,23 @@ defmodule GameServer do
   end
 
   # Rotates the ship with the given name in the given direction
-  @impl true
-  def handle_cast({:rotate, name, dir}, %{players: players} = state) do
-    # player = Enum.find(players, fn player -> player.name == name end)
+  # @impl true
+  # def handle_cast({:rotate, name, dir}, %{players: players} = state) do
+  #   player = Enum.find(players, fn player -> player.name == name end)
 
-    # if player == :default do
-    #   {:noreply, state}
-    # else
-    #   if dir == :cw || dir == :ccw do
-    #     updated_players =
-    #       update_players(players, Movable.Rotation.rotate(player, @turn_rate, dir))
+  #   if player == :default do
+  #     {:noreply, state}
+  #   else
+  #     if dir == :cw || dir == :ccw do
+  #       updated_players =
+  #         update_players(players, Movable.Rotation.rotate(player, @turn_rate, dir))
 
-    #     {:noreply, %{state | :players => updated_players}}
-    #   else
-    #     {:noreply, state}
-    #   end
-    # end
-  end
+  #       {:noreply, %{state | :players => updated_players}}
+  #     else
+  #       {:noreply, state}
+  #     end
+  #   end
+  # end
 
   @doc "Removes a player from the game state."
   @impl true

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -94,7 +94,7 @@ defmodule GameServer do
     GenServer.cast({:global, __MODULE__}, {:input, :fire, :released, name})
   end
 
-  @doc "Handles all idle ship movement/velocity. Should be called every tick."
+  @doc "Handles any and all idle movement/velocity. Should be called every tick for any movable entity."
   def move_all(movables), do: Enum.map(movables, fn movable -> Movable.Motion.move(movable) end)
 
   @doc "Given a player and player list, replaces players with the same name in the list and returns the new list."

--- a/project_quazar/lib/project_quazar/game/game_server.ex
+++ b/project_quazar/lib/project_quazar/game/game_server.ex
@@ -40,10 +40,10 @@ defmodule GameServer do
   #   GenServer.cast({:global, __MODULE__}, {:accel, name})
   # end
 
-  @doc "Rotates the ship with the given name in the given direction."
-  def rotate_player(name, dir) do
-    GenServer.cast({:global, __MODULE__}, {:rotate, name, dir})
-  end
+  # @doc "Rotates the ship with the given name in the given direction."
+  # def rotate_player(name, dir) do
+  #   GenServer.cast({:global, __MODULE__}, {:rotate, name, dir})
+  # end
 
   @doc "Removes a player from the player list"
   def remove_player(name) do
@@ -54,38 +54,47 @@ defmodule GameServer do
     GenServer.cast({:global, __MODULE__}, {:remove_leftover_players, presence_list})
   end
 
-  def accelerate_pressed() do
-
+  @doc "Accelerates the Player with the given name."
+  def accelerate_pressed(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :accelerate_pressed, name})
   end
 
-  def accelerate_released() do
-
+  @doc "Stops accelerating the specfied player."
+  def accelerate_released(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :accelerate_released, name})
   end
 
-  def turn_right_pressed() do
-
+  @doc "Turns a specfied player right (clockwise)."
+  def turn_right_pressed(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_right_pressed, name})
   end
 
-  def turn_right_released() do
-
+  @doc "Stops a specfied player from turning right."
+  def turn_right_released(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_right_released, name})
   end
 
-  def turn_left_pressed() do
-
+  @doc "Turns a specfied player left (counter-clockwise)."
+  def turn_left_pressed(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_left_pressed, name})
   end
 
-  def turn_left_released() do
-
+  @doc "Stops a specfied player from turning left."
+  def turn_left_released(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :turn_left_released, name})
   end
 
-  def fire_pressed() do
-
+  @doc "Fires bullets from a specfied player."
+  def fire_pressed(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :fire_pressed, name})
   end
 
-  def fire_released() do
-
+  @doc "Stops firing bullets from a specified player."
+  def fire_released(name) do
+    GenServer.cast({:global, __MODULE__}, {:input, :fire_released, name})
   end
 
+  @doc "Handles all idle ship movement/velocity. Should be called every tick."
   def move_all(movables), do: Enum.map(movables, fn movable -> Movable.Motion.move(movable) end)
 
   @doc "Given a player and player list, replaces players with the same name in the list and returns the new list."
@@ -201,14 +210,14 @@ defmodule GameServer do
   # Accelerate the Player with the given name.
   @impl true
   def handle_cast({:accel, name}, %{players: players} = state) do
-    player = Enum.find(players, fn player -> player.name == name end)
+    # player = Enum.find(players, fn player -> player.name == name end)
 
-    if player == :default do
-      {:noreply, state}
-    else
-      updated_players = update_players(players, Movable.Motion.accelerate(player, @accel_rate))
-      {:noreply, %{state | :players => updated_players}}
-    end
+    # if player == :default do
+    #   {:noreply, state}
+    # else
+    #   updated_players = update_players(players, Movable.Motion.accelerate(player, @accel_rate))
+    #   {:noreply, %{state | :players => updated_players}}
+    # end
   end
 
   @doc """
@@ -217,35 +226,35 @@ defmodule GameServer do
   @impl true
   def handle_cast({:fire, name}, %{players: players, projectiles: projectiles} = state) do
     # Find the player who is firing
-    player = Enum.find(players, fn player -> player.name == name end)
-    case Ship.fire(player.ship, player.name) do
-      {:ok, bullet} ->
-        # Add the new bullet to the projectile list
-        new_projectiles = [bullet | projectiles]
-        {:noreply, %{state | projectiles: new_projectiles}}
-      :error ->
-        {:noreply, state}
-    end
+    # player = Enum.find(players, fn player -> player.name == name end)
+    # case Ship.fire(player.ship, player.name) do
+    #   {:ok, bullet} ->
+    #     # Add the new bullet to the projectile list
+    #     new_projectiles = [bullet | projectiles]
+    #     {:noreply, %{state | projectiles: new_projectiles}}
+    #   :error ->
+    #     {:noreply, state}
+    # end
 
   end
 
   # Rotates the ship with the given name in the given direction
   @impl true
   def handle_cast({:rotate, name, dir}, %{players: players} = state) do
-    player = Enum.find(players, fn player -> player.name == name end)
+    # player = Enum.find(players, fn player -> player.name == name end)
 
-    if player == :default do
-      {:noreply, state}
-    else
-      if dir == :cw || dir == :ccw do
-        updated_players =
-          update_players(players, Movable.Rotation.rotate(player, @turn_rate, dir))
+    # if player == :default do
+    #   {:noreply, state}
+    # else
+    #   if dir == :cw || dir == :ccw do
+    #     updated_players =
+    #       update_players(players, Movable.Rotation.rotate(player, @turn_rate, dir))
 
-        {:noreply, %{state | :players => updated_players}}
-      else
-        {:noreply, state}
-      end
-    end
+    #     {:noreply, %{state | :players => updated_players}}
+    #   else
+    #     {:noreply, state}
+    #   end
+    # end
   end
 
   @doc "Removes a player from the game state."

--- a/project_quazar/lib/project_quazar/game/player.ex
+++ b/project_quazar/lib/project_quazar/game/player.ex
@@ -53,7 +53,7 @@ defmodule Player do
   end
 
   @doc "Updates the players input mapping values based on the passed value"
-  def update_player_inputs(%__MODULE__{} = player, action, pressed_or_released) do
+  def update_inputs(%__MODULE__{} = player, action, pressed_or_released) do
     # Convert pressed/release event into true/false values for input map
     value = case pressed_or_released do
       :pressed -> true

--- a/project_quazar/lib/project_quazar/game/player.ex
+++ b/project_quazar/lib/project_quazar/game/player.ex
@@ -9,11 +9,11 @@ defmodule Player do
 
   # Player name, `Ship`, & current score.
   @derive Jason.Encoder
-  defstruct [:name, :ship, :score]
+  defstruct [:name, :ship, :score, :inputs]
 
   @doc "Creates a new player with a given name and ship (created from `Ship` module)"
   def new_player(name, ship) do
-    %__MODULE__{name: name, ship: ship, score: 0}
+    %__MODULE__{name: name, ship: ship, score: 0, inputs: %{}}
   end
 
   @doc "Increments the score by an amount."
@@ -47,6 +47,18 @@ defmodule Player do
   def respawn(%__MODULE__{ship: ship} = player_data, px, py, angle) do
     respawned_ship = Ship.respawn(ship, px, py, angle)
     %__MODULE__{player_data | score: 0, ship: respawned_ship}
+  end
+
+  @doc "Updates the players input mapping values based on the passed value"
+  def update_player_inputs(%__MODULE__{} = player, action, pressed_or_released) do
+    # Convert pressed/release event into true/false values for input map
+    value = case pressed_or_released do
+      :pressed -> true
+      :released -> false
+    end
+    # Update the players input map
+    new_inputs = Map.put(player.inputs, action, value)
+    %Player{player | inputs: new_inputs} # Return the player with new inputs
   end
 
   defimpl Movable.Motion, for: __MODULE__ do

--- a/project_quazar/lib/project_quazar/game_prototype/game_prototype.ex
+++ b/project_quazar/lib/project_quazar/game_prototype/game_prototype.ex
@@ -32,7 +32,7 @@ defmodule GamePrototype do
 
   # Function to start the loop
   defp start_loop() do
-    # Process.send_after(self(), :print_message, 1000)
+    Process.send_after(self(), :print_message, 1000)
   end
 
   # Function to handle the loop


### PR DESCRIPTION
This should be one if not the final piece to make it so the front-end can effectively communicate to players on the backend.

This is vital to the functionality of the game and should nearly finalize the front-end to GameServer API calls.

# Changes made
- Added `inputs` map to players containing key/value pairs of actions (accelerate, turn_left, turn_right, brake, etc.)
  - Added `update_inputs` and `handle_inputs` functions to `Player` to allow GameServer to update each player individually on tick
- Added `acceleration_pressed`, `acceleration_released`, etc. functions for the front-end events to call in `GameServer` which map the above mentioned input values to a cast.
- Added `add_projectile` cast to GameServer for Player to call on `handle_inputs` (_Note:_ This seems quite weird to me but it appears to work; if someone can think of a better solution please let me know.)
- Updated `modify_players` function to (mostly) how each player should be updated on each tick
  - Alive players should allow for their input to be used (Rotate, accelerate, stop)
  - *Alive players should also increase health every tick if they manage to stay alive
  - All players (dead or alive) should move and be slowly dragged to a halt based on their last velocity
- Removed duplicate `tick_rate` module attribute
- Removed `accel_rate` because we should be using a Ship's acceleration value (`ship.acceleration`)
- Removed `score_increment` because we are going to use damage values (See #44)
- Added some documentation/cleaned documentation style for many GameServer functions to prevent excess console warnings
- Fixed order of `GameServer` functions to prevent excessive arity/function grouping warnings

# ⚠️Warning!
This is a major change, and _will_ break the prototypes and liveserver pages because many functions have likely changed. Please do all testing either with updated frontend functionality (not included ATM in this PR) or run the server with `iex -S mix`